### PR TITLE
fix: add ESM interop

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "outDir": "./dist",
     "inlineSources": false,
     "inlineSourceMap": false,
-    "esModuleInterop": false,
+    "esModuleInterop": true,
     "declaration": true,
     "skipLibCheck": true
   }


### PR DESCRIPTION
## Motivation
We want ESM interop here currently seeing issues like:

`TypeError: (0 , async_retry_1.default) is not a function`

This fixes those issues.