### PR TITLE
feat: add a simple scan table method with filter option

### DIFF
--- a/src/dynamo-expressions.ts
+++ b/src/dynamo-expressions.ts
@@ -244,7 +244,7 @@ const createRefContext = (): RefContext => {
  * Returns DynamoDB client parameters describing the specified condition.
  */
 export const serializeCondition = <Entity>(
-  condition: DynamoDBCondition<Entity>,
+  condition: DynamoDBCondition<Entity> = {},
 ): Pick<
   PutCommandInput,
   | 'ConditionExpression'

--- a/src/dynamo-table.test.ts
+++ b/src/dynamo-table.test.ts
@@ -186,7 +186,7 @@ describe('DynamoTable', () => {
 
       const fullSet = await userTable.scan();
 
-      expect(fullSet.items).toHaveLength(1);
+      expect(fullSet.items).toHaveLength(3);
       expect(fullSet.nextPageToken).not.toBeDefined();
     });
 

--- a/src/dynamo-table.test.ts
+++ b/src/dynamo-table.test.ts
@@ -183,6 +183,11 @@ describe('DynamoTable', () => {
 
       expect(filteredSet.items).toHaveLength(1);
       expect(filteredSet.nextPageToken).toBeDefined();
+
+      const fullSet = await userTable.scan();
+
+      expect(fullSet.items).toHaveLength(1);
+      expect(fullSet.nextPageToken).not.toBeDefined();
     });
 
     it('can scan the table with a filter', async () => {

--- a/src/dynamo-table.test.ts
+++ b/src/dynamo-table.test.ts
@@ -250,6 +250,22 @@ describe('DynamoTable', () => {
           createdAt: '2020-01-01T23:00:00.000Z',
         },
       ]);
+
+      const usersByMultipleConditions = await userTable.scan({
+        filter: {
+          'greater-than': { id: 'user-1' },
+          'less-than': { id: 'user-3' },
+        },
+      });
+
+      expect(usersByMultipleConditions.items).toHaveLength(1);
+      expect(usersByMultipleConditions.items).toStrictEqual([
+        {
+          id: 'user-2',
+          account: 'account-1',
+          createdAt: '2019-01-01T23:00:00.000Z',
+        },
+      ]);
     });
   });
 

--- a/src/dynamo-table.test.ts
+++ b/src/dynamo-table.test.ts
@@ -137,6 +137,46 @@ describe('DynamoTable', () => {
     });
   });
 
+  describe('scan', () => {
+    it('can scan a table with pagination', async () => {
+      const { userTable } = setupDb();
+
+      // seed the db
+      await userTable.batchPut([
+        {
+          id: 'user-1',
+          account: 'account-1',
+          createdAt: new Date().toISOString(),
+        },
+        {
+          id: 'user-2',
+          account: 'account-1',
+          createdAt: new Date().toISOString(),
+        },
+        {
+          id: 'user-3',
+          account: 'account-2',
+          createdAt: new Date().toISOString(),
+        },
+      ]);
+
+      const firstSet = await userTable.scan({
+        limit: 2,
+      });
+
+      expect(firstSet.items).toHaveLength(2);
+      expect(firstSet.nextPageToken).toBeDefined();
+
+      const secondSet = await userTable.scan({
+        limit: 2,
+        nextPageToken: firstSet.nextPageToken,
+      });
+
+      expect(secondSet.items).toHaveLength(1);
+      expect(secondSet.nextPageToken).not.toBeDefined();
+    });
+  });
+
   describe('deleteAll', () => {
     it('deletes all the records that match the query', async () => {
       // TODO


### PR DESCRIPTION
## Motivation

Found a need for using a scan operation on a dynamo table and I wanted to use `dynamost`

If we prefer to not support filtering quite yet (could be some edge cases I've not considered) we could consider just doing https://github.com/lifeomic/dynamost/pull/16 for now