### PR TITLE
fix: remove type-fest to improve compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "@types/async-retry": "^1.4.5",
     "async-retry": "^1.3.3",
     "lodash": "^4.17.21",
-    "p-map": "^4.0.0",
-    "type-fest": "^4.3.1"
+    "p-map": "^4.0.0"
   },
   "devDependencies": {
     "@aws-sdk/client-dynamodb": "^3.363.0",

--- a/src/dynamo-expressions.ts
+++ b/src/dynamo-expressions.ts
@@ -3,7 +3,6 @@ import {
   QueryCommandInput,
   UpdateCommandInput,
 } from '@aws-sdk/lib-dynamodb';
-import { SetRequired } from 'type-fest';
 
 import { KeySchema } from './';
 
@@ -310,22 +309,22 @@ export type SerializeUpdateParams<Entity> = {
   condition?: DynamoDBCondition<Entity>;
 };
 
+type SerializeUpdateReturn = Pick<
+  UpdateCommandInput,
+  | 'ConditionExpression'
+  | 'ExpressionAttributeNames'
+  | 'ExpressionAttributeValues'
+> & {
+  UpdateExpression: string;
+};
+
 /**
  * Returns DynamoDB client parameters describing the specified update.
  */
 export const serializeUpdate = <Entity>({
   update,
   condition,
-}: SerializeUpdateParams<Entity>): SetRequired<
-  Pick<
-    UpdateCommandInput,
-    | 'UpdateExpression'
-    | 'ConditionExpression'
-    | 'ExpressionAttributeNames'
-    | 'ExpressionAttributeValues'
-  >,
-  'UpdateExpression'
-> => {
+}: SerializeUpdateParams<Entity>): SerializeUpdateReturn => {
   const {
     getSubjectRef,
     getObjectRef,

--- a/src/transaction-manager.ts
+++ b/src/transaction-manager.ts
@@ -1,12 +1,17 @@
 import { DynamoDBDocument } from '@aws-sdk/lib-dynamodb';
-import { RequireExactlyOne } from 'type-fest';
 
 type WriteTransactionItem = NonNullable<
   Parameters<DynamoDBDocument['transactWrite']>[0]['TransactItems']
 >[0];
 
+export type TransactionItem =
+  | Pick<WriteTransactionItem, 'ConditionCheck'>
+  | Pick<WriteTransactionItem, 'Put'>
+  | Pick<WriteTransactionItem, 'Delete'>
+  | Pick<WriteTransactionItem, 'Update'>;
+
 export interface Transaction {
-  addWrite(writeItem: RequireExactlyOne<WriteTransactionItem>): void;
+  addWrite(writeItem: TransactionItem): void;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -6811,11 +6811,6 @@ type-fest@^3.0.0, type-fest@^3.12.0, type-fest@^3.8.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.12.0.tgz#4ce26edc1ccc59fc171e495887ef391fe1f5280e"
   integrity sha512-qj9wWsnFvVEMUDbESiilKeXeHL7FwwiFcogfhfyjmvT968RXSvnl23f1JOClTHYItsi7o501C/7qVllscUP3oA==
 
-type-fest@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.3.1.tgz#5cb58cdab5120f7ab0b40cfdc35073fb9adb651d"
-  integrity sha512-pphNW/msgOUSkJbH58x8sqpq8uQj6b0ZKGxEsLKMUnGorRcDjrUaLS+39+/ub41JNTwrrMyJcUB8+YZs3mbwqw==
-
 typescript@^5.1.6:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"


### PR DESCRIPTION
## Motivation
I'd like to propose removing `type-fest` to improve the compatibility of this library. The current version of `type-fest` used here has an implicit requirement around the version of TypeScript, and I'm struggling to identify it.

In my experience, this is common with `type-fest` -- since they're providing complex typings, they often rely on TS syntax that may be only recently supported, or is at the least version specific.

While I love `type-fest`, I think this might make it not ideal for _this project_, which is itself a package. Removing `type-fest` will make the project more compatible with consumers of various TypeScript versions.